### PR TITLE
Move ansible's default interface to front of interface list

### DIFF
--- a/app/services/foreman_ansible/fact_parser.rb
+++ b/app/services/foreman_ansible/fact_parser.rb
@@ -41,7 +41,13 @@ module ForemanAnsible
     end
 
     def get_interfaces
-      facts[:ansible_interfaces]
+      # Move ansibles default interface first in the list of interfaces since
+      # Foreman picks the first one that is usable. If ansible has no
+      # preference otherwise at least sort the list.
+      pref = facts[:ansible_default_ipv4] &&
+                facts[:ansible_default_ipv4]['interface']
+      pref ? (facts[:ansible_interfaces] - [pref]).unshift(pref) :
+                facts[:ansible_interfaces].sort
     end
 
     def get_facts_for_interface(interface)


### PR DESCRIPTION
Foreman's FactParser.suggested_primary_interface picks the first physical or
virtual interface. In order to make sure we favour the one preferred by ansible
put it in the front of the list.

If there's no preferred interface at leats sort the list so it's at least
deterministic.

Mabe not that important but it looks nicer if we don't make an arbitrary interface the primary one.