### PR TITLE
Provide additional report details

### DIFF
--- a/extras/foreman_callback.py
+++ b/extras/foreman_callback.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 import json
 import uuid
 import requests
+import time
 
 try:
     from ansible.plugins.callback import CallbackBase
@@ -43,6 +44,7 @@ class CallbackModule(parent_class):
     """
     def __init__(self):
         self.items = defaultdict(list)
+        self.start_time = int(time.time())
 
     def log(self, host, category, data):
         if type(data) != dict:
@@ -108,6 +110,7 @@ class CallbackModule(parent_class):
             status["failed"] = sum['failures'] + sum['unreachable']
             status["skipped"] = sum['skipped']
             log = self._build_log(self.items[host])
+            metrics["time"] = { "total": int(time.time()) - self.start_time }
             self.items[host] = []
 
             report_json = REPORT_FORMAT % dict(host=host,

--- a/extras/foreman_callback.py
+++ b/extras/foreman_callback.py
@@ -44,12 +44,13 @@ class CallbackModule(object):
             self.send_facts(host, data)
         self.send_report(host, data)
 
-    """
-    Sends facts to Foreman, to be parsed by foreman_ansible fact parser.
-    The default fact importer should import these facts properly.
-    """
 
     def send_facts(self, host, data):
+        """
+        Sends facts to Foreman, to be parsed by foreman_ansible fact
+        parser.  The default fact importer should import these facts
+        properly.
+        """
         data["_type"] = "ansible"
         data["_timestamp"] = datetime.now().strftime(TIME_FORMAT)
         data = json.dumps(data)
@@ -59,18 +60,19 @@ class CallbackModule(object):
                       headers=FOREMAN_HEADERS,
                       verify=False)
 
-    """
-    Send reports to Foreman, to be parsed by Foreman config report importer.
-    I massage the data get a report json that Foreman can handle without
-    writing another report importer.
-
-    Currently it just sets the status. It's missing:
-      - metrics, which we can get from data, except for runtime
-      - proper count for playbook tasks, currently it's 1 no matter how
-        many modules have run
-    """
-
     def send_report(self, host, data):
+        """
+        Send reports to Foreman, to be parsed by Foreman config report
+        importer.  I massage the data get a report json that Foreman
+        can handle without writing another report importer.
+
+        Currently it just sets the status. It's missing:
+          - metrics, which we can get from data, except for runtime
+          - proper count for playbook tasks, currently it's 1 no
+            matter how many modules have run
+        """
+
+
         status = defaultdict(lambda:0)
         log = { 'messages' : { 'message' : '' },
                 'sources' :  { 'source' : ''} }


### PR DESCRIPTION
These are four patches for the ansible callback:

* the first one just moves the docs to the proper location
* the second one makes sure we don't hammer on the report API like crazy for one task at a time
* the third one tries to fill the log entries with some sense
* the 4th one uses ansibles v2 plugin API to use the ansible task name as resource name

This might need more work so just let me know if this is heading into the right direction. With this applied the logs are a bit closer as what one gets with puppet.